### PR TITLE
Use correct permission when creating netrc file

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -26,7 +26,7 @@ workflows:
         - username: $USERNAME
         - password: $PASSWORD
     - path::./:
-        title: Step Test
+        title: Execute step second time
         inputs:
         - host: $HOST
         - username: $USERNAME
@@ -39,6 +39,16 @@ workflows:
 
             cat ~/.netrc
             echo ""
+    - script:
+        title: Check file permission
+        inputs:
+        - content: |-
+            set -ex
+
+            if [ $(stat -f "%A" ~/.netrc) != 600 ]; then
+              echo "netrc file permission is not 600"
+              exit 1
+            fi
     - script:
         title: Restore .netrc
         inputs:

--- a/netrcutil/netrcutil.go
+++ b/netrcutil/netrcutil.go
@@ -2,6 +2,7 @@ package netrcutil
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/bitrise-io/go-utils/fileutil"
@@ -37,7 +38,8 @@ func (netRCModel *NetRCModel) AddItemModel(itemModels ...NetRCItemModel) {
 // CreateFile ...
 func (netRCModel *NetRCModel) CreateFile() error {
 	netRCFileContent := generateFileContent(netRCModel)
-	return fileutil.WriteStringToFile(netRCModel.OutputPth, netRCFileContent)
+	permission := os.FileMode(0600) // Other tools might fail if the file's permission is not 0600
+	return fileutil.WriteStringToFileWithPermission(netRCModel.OutputPth, netRCFileContent, permission)
 }
 
 // Append ...


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context
Resolves #8 

### Changes

- Use `0600` file permission when creating the `.netrc` file

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
