### PR TITLE
Insert newline at the end of the .netrc file

### DIFF
--- a/netrcutil/netrcutil.go
+++ b/netrcutil/netrcutil.go
@@ -45,7 +45,7 @@ func (netRCModel *NetRCModel) CreateFile() error {
 // Append ...
 func (netRCModel *NetRCModel) Append() error {
 	netRCFileContent := generateFileContent(netRCModel)
-	return fileutil.AppendStringToFile(netRCModel.OutputPth, fmt.Sprintf("\n\n%s\n", netRCFileContent))
+	return fileutil.AppendStringToFile(netRCModel.OutputPth, fmt.Sprintf("\n\n%s", netRCFileContent))
 }
 
 func generateFileContent(netRCModel *NetRCModel) string {

--- a/netrcutil/netrcutil.go
+++ b/netrcutil/netrcutil.go
@@ -45,13 +45,13 @@ func (netRCModel *NetRCModel) CreateFile() error {
 // Append ...
 func (netRCModel *NetRCModel) Append() error {
 	netRCFileContent := generateFileContent(netRCModel)
-	return fileutil.AppendStringToFile(netRCModel.OutputPth, fmt.Sprintf("\n\n%s", netRCFileContent))
+	return fileutil.AppendStringToFile(netRCModel.OutputPth, fmt.Sprintf("\n\n%s\n", netRCFileContent))
 }
 
 func generateFileContent(netRCModel *NetRCModel) string {
 	netRCFileContent := ""
 	for i, itemModel := range netRCModel.ItemModels {
-		netRCFileContent += fmt.Sprintf("machine %s\n\tlogin %s\n\tpassword %s", itemModel.Machine, itemModel.Login, itemModel.Password)
+		netRCFileContent += fmt.Sprintf("machine %s\n\tlogin %s\n\tpassword %s\n", itemModel.Machine, itemModel.Login, itemModel.Password)
 		if i != len(netRCModel.ItemModels)-1 {
 			netRCFileContent += "\n\n"
 		}

--- a/netrcutil/netrcutil_test.go
+++ b/netrcutil/netrcutil_test.go
@@ -25,7 +25,6 @@ const testAppendFileContent = `machine testhost.com
 machine testhost2.com
 	login testusername2
 	password testpassword2
-
 `
 
 func TestCreateFile(t *testing.T) {

--- a/netrcutil/netrcutil_test.go
+++ b/netrcutil/netrcutil_test.go
@@ -14,15 +14,19 @@ import (
 
 const testCreateFileContent = `machine testhost.com
 	login testusername
-	password testpassword`
+	password testpassword
+`
 
 const testAppendFileContent = `machine testhost.com
 	login testusername
 	password testpassword
 
+
 machine testhost2.com
 	login testusername2
-	password testpassword2`
+	password testpassword2
+
+`
 
 func TestCreateFile(t *testing.T) {
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context
Due to a regression in the version of curl shipped with macOS Ventura 13.2, there needs to be a newline at the end of the .netrc file for it to be read properly. This is fixed in the next version of curl, but we have no guarantees as to when that will be included.
<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Resolves: https://github.com/bitrise-steplib/steps-authenticate-host-with-netrc/issues/12

### Changes
This change adds a newline when there is a new .netrc file or when we are appending to one.
<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details
This only affects curl version 7.86.0 which is the one shipped with macOS Ventura 13.2. Another solution is to wait for Apple to ship curl 7.87.0 or newer, but we don't know their timeline for that or if it will even be included in their next patch version.
<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
