### PR TITLE
Avoid multiple backup copies

### DIFF
--- a/netrcutil/netrcutil.go
+++ b/netrcutil/netrcutil.go
@@ -52,29 +52,35 @@ func (netRCModel *NetRCModel) CreateOrUpdateFile(itemModels ...NetRCItemModel) e
 	} else {
 		log.Warnf("File already exists at (%s)", netRCModel.OutputPth)
 
-		backupBase := strings.Replace(netRCModel.OutputPth, ".netrc", ".bk.netrc", -1)
-		backups, err := filepath.Glob(backupBase + "*")
+		existingContent, err := fileutil.ReadStringFromFile(netRCModel.OutputPth)
 		if err != nil {
-			return fmt.Errorf("Failed to find backup files, error: %s", err)
+			return fmt.Errorf("Failed to read file (%s), error: %s", netRCModel.OutputPth, err)
 		}
 
-		if len(backups) == 0 {
-			backupPth := fmt.Sprintf("%s%s", backupBase, time.Now().Format("2006_01_02_15_04_05"))
-
-			if originalContent, err := fileutil.ReadBytesFromFile(netRCModel.OutputPth); err != nil {
-				return fmt.Errorf("Failed to read file (%s), error: %s", netRCModel.OutputPth, err)
-			} else if err := fileutil.WriteBytesToFile(backupPth, originalContent); err != nil {
-				return fmt.Errorf("Failed to write file (%s), error: %s", backupPth, err)
-			} else {
-				log.Printf("Backup created at: %s", backupPth)
+		missingItems := []NetRCItemModel{}
+		for _, item := range netRCModel.ItemModels {
+			entry := generateItemContent(item)
+			if !strings.Contains(existingContent, entry) {
+				missingItems = append(missingItems, item)
 			}
-		} else {
-			log.Printf("Backup already exists at: %s", backups[0])
 		}
+
+		if len(missingItems) == 0 {
+			log.Printf(".netrc already contains the provided configuration, skipping update")
+			return nil
+		}
+
+		backupPth := fmt.Sprintf("%s%s", strings.Replace(netRCModel.OutputPth, ".netrc", ".bk.netrc", -1), time.Now().Format("2006_01_02_15_04_05"))
+
+		if err := fileutil.WriteBytesToFile(backupPth, []byte(existingContent)); err != nil {
+			return fmt.Errorf("Failed to write file (%s), error: %s", backupPth, err)
+		}
+		log.Printf("Backup created at: %s", backupPth)
 
 		log.Printf("Appending config to the existing .netrc file...")
 
-		if err := netRCModel.Append(); err != nil {
+		appendModel := &NetRCModel{OutputPth: netRCModel.OutputPth, ItemModels: missingItems}
+		if err := appendModel.Append(); err != nil {
 			return fmt.Errorf("Failed to write .netrc file, error: %s", err)
 		}
 	}
@@ -109,4 +115,9 @@ func generateFileContent(netRCModel *NetRCModel) string {
 		}
 	}
 	return netRCFileContent
+}
+
+func generateItemContent(item NetRCItemModel) string {
+	m := &NetRCModel{ItemModels: []NetRCItemModel{item}}
+	return generateFileContent(m)
 }

--- a/netrcutil/netrcutil.go
+++ b/netrcutil/netrcutil.go
@@ -52,14 +52,24 @@ func (netRCModel *NetRCModel) CreateOrUpdateFile(itemModels ...NetRCItemModel) e
 	} else {
 		log.Warnf("File already exists at (%s)", netRCModel.OutputPth)
 
-		backupPth := fmt.Sprintf("%s%s", strings.Replace(netRCModel.OutputPth, ".netrc", ".bk.netrc", -1), time.Now().Format("2006_01_02_15_04_05"))
+		backupBase := strings.Replace(netRCModel.OutputPth, ".netrc", ".bk.netrc", -1)
+		backups, err := filepath.Glob(backupBase + "*")
+		if err != nil {
+			return fmt.Errorf("Failed to find backup files, error: %s", err)
+		}
 
-		if originalContent, err := fileutil.ReadBytesFromFile(netRCModel.OutputPth); err != nil {
-			return fmt.Errorf("Failed to read file (%s), error: %s", netRCModel.OutputPth, err)
-		} else if err := fileutil.WriteBytesToFile(backupPth, originalContent); err != nil {
-			return fmt.Errorf("Failed to write file (%s), error: %s", backupPth, err)
+		if len(backups) == 0 {
+			backupPth := fmt.Sprintf("%s%s", backupBase, time.Now().Format("2006_01_02_15_04_05"))
+
+			if originalContent, err := fileutil.ReadBytesFromFile(netRCModel.OutputPth); err != nil {
+				return fmt.Errorf("Failed to read file (%s), error: %s", netRCModel.OutputPth, err)
+			} else if err := fileutil.WriteBytesToFile(backupPth, originalContent); err != nil {
+				return fmt.Errorf("Failed to write file (%s), error: %s", backupPth, err)
+			} else {
+				log.Printf("Backup created at: %s", backupPth)
+			}
 		} else {
-			log.Printf("Backup created at: %s", backupPth)
+			log.Printf("Backup already exists at: %s", backups[0])
 		}
 
 		log.Printf("Appending config to the existing .netrc file...")

--- a/netrcutil/netrcutil_test.go
+++ b/netrcutil/netrcutil_test.go
@@ -140,6 +140,35 @@ func TestCreateOrUpdateFile(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, testCreateFileContent, backupContent)
 	})
+
+	t.Run("when backup already exists", func(t *testing.T) {
+		netRC, tmpDir, cleanup := setup(t)
+		defer cleanup()
+
+		// First run to create .netrc and backup
+		initial := New()
+		initial.OutputPth = netRC.OutputPth
+		err := initial.CreateOrUpdateFile(NetRCItemModel{Machine: "testhost.com", Login: "testusername", Password: "testpassword"})
+		require.NoError(t, err)
+
+		// Second run should not create another backup
+		err = netRC.CreateOrUpdateFile(NetRCItemModel{Machine: "testhost2.com", Login: "testusername2", Password: "testpassword2"})
+		require.NoError(t, err)
+
+		err = netRC.CreateOrUpdateFile(NetRCItemModel{Machine: "testhost3.com", Login: "testusername3", Password: "testpassword3"})
+		require.NoError(t, err)
+
+		// verify only one backup file exists
+		found := 0
+		err = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
+			if !info.IsDir() && path != netRC.OutputPth {
+				found += 1
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, found)
+	})
 }
 
 func setup(t *testing.T) (*NetRCModel, string, func()) {

--- a/netrcutil/netrcutil_test.go
+++ b/netrcutil/netrcutil_test.go
@@ -141,24 +141,26 @@ func TestCreateOrUpdateFile(t *testing.T) {
 		require.Equal(t, testCreateFileContent, backupContent)
 	})
 
-	t.Run("when backup already exists", func(t *testing.T) {
+	t.Run("when the same config already exists", func(t *testing.T) {
 		netRC, tmpDir, cleanup := setup(t)
 		defer cleanup()
 
-		// First run to create .netrc and backup
-		initial := New()
-		initial.OutputPth = netRC.OutputPth
-		err := initial.CreateOrUpdateFile(NetRCItemModel{Machine: "testhost.com", Login: "testusername", Password: "testpassword"})
+		first := New()
+		first.OutputPth = netRC.OutputPth
+		err := first.CreateOrUpdateFile(NetRCItemModel{Machine: "testhost.com", Login: "testusername", Password: "testpassword"})
 		require.NoError(t, err)
 
-		// Second run should not create another backup
-		err = netRC.CreateOrUpdateFile(NetRCItemModel{Machine: "testhost2.com", Login: "testusername2", Password: "testpassword2"})
+		infoBefore, err := os.Stat(netRC.OutputPth)
 		require.NoError(t, err)
 
-		err = netRC.CreateOrUpdateFile(NetRCItemModel{Machine: "testhost3.com", Login: "testusername3", Password: "testpassword3"})
+		err = netRC.CreateOrUpdateFile(NetRCItemModel{Machine: "testhost.com", Login: "testusername", Password: "testpassword"})
 		require.NoError(t, err)
 
-		// verify only one backup file exists
+		infoAfter, err := os.Stat(netRC.OutputPth)
+		require.NoError(t, err)
+		require.Equal(t, infoBefore.ModTime(), infoAfter.ModTime())
+
+		// ensure no backup file created
 		found := 0
 		err = filepath.Walk(tmpDir, func(path string, info os.FileInfo, err error) error {
 			if !info.IsDir() && path != netRC.OutputPth {
@@ -167,7 +169,7 @@ func TestCreateOrUpdateFile(t *testing.T) {
 			return nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, 1, found)
+		require.Equal(t, 0, found)
 	})
 }
 


### PR DESCRIPTION
The step creates a backup if an existing `.netrc` file is found. In persistent environments (bare-metal machines), this leads to a flood of backup files, slowly filling up the disk.

### Changes

- ensure only one `.netrc` backup is created
- test that repeated runs do not create additional backup files


